### PR TITLE
feat: Overhaul Media Vault and add new features

### DIFF
--- a/DouXManager.h
+++ b/DouXManager.h
@@ -43,6 +43,7 @@
 + (BOOL)appLock;
 + (BOOL)flexEnabled;
 + (BOOL)showVaultButton;
++ (BOOL)blockShopVideos;
 + (void)showSaveVC:(NSArray<NSURL *> *)item;
 + (void)cleanCache;
 + (BOOL)isEmpty:(NSURL *)url;

--- a/DouXManager.m
+++ b/DouXManager.m
@@ -132,6 +132,10 @@ static os_log_t douxmanager_log;
 + (BOOL)showVaultButton {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"show_vault_button"];
 }
+
++ (BOOL)blockShopVideos {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"block_shop_videos"];
+}
 + (void)cleanCache {
     NSArray <NSURL *> *DocumentFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:[NSURL fileURLWithPath:NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true).firstObject] includingPropertiesForKeys:@[] options:NSDirectoryEnumerationSkipsHiddenFiles error:nil];
     

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include $(THEOS)/makefiles/common.mk
 TWEAK_NAME = DouX
 
 DouX_LIBRARIES = JGProgressHUD
-DouX_FILES = Tweak.x $(wildcard hooks/*.x) DouXDownload.m DouXManager.m DouXMultipleDownload.m SecurityViewController.m VaultMediaItem.m VaultManager.m VaultViewController.m PhotoViewController.m CreatorFilterViewController.m ContentTypeFilterViewController.m FilterViewController.m $(wildcard Settings/*.m)
+DouX_FILES = Tweak.x $(wildcard hooks/*.x) DouXDownload.m DouXManager.m DouXMultipleDownload.m SecurityViewController.m VaultMediaItem.m VaultManager.m VaultViewController.m VaultItemsViewController.m VaultContentTypesViewController.m VaultStatsViewController.m VaultFileViewerViewController.m PhotoViewController.m CreatorFilterViewController.m ContentTypeFilterViewController.m FilterViewController.m $(wildcard Settings/*.m)
 DouX_FRAMEWORKS = UIKit Foundation CoreGraphics Photos CoreServices SystemConfiguration SafariServices Security QuartzCore Photos
 DouX_CFLAGS = -fobjc-arc -Wno-unused-variable -Wno-unused-value -Wno-deprecated-declarations -Wno-nullability-completeness -Wno-unused-function -Wno-incompatible-pointer-types -I./libs/JGProgressHUD
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A powerful iOS tweak that enhances your TikTok experience with additional featur
 [![Language](https://img.shields.io/badge/language-Objective--C-orange.svg)](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/Introduction/Introduction.html)
 [![Framework](https://img.shields.io/badge/framework-Theos-red.svg)](https://theos.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/WUyHNFYGSF)
+
 
 ## Key Features
 

--- a/SecurityViewController.m
+++ b/SecurityViewController.m
@@ -1,5 +1,6 @@
 #import "SecurityViewController.h"
 #import "VaultViewController.h"
+#import "VaultManager.h"
 
 @implementation SecurityViewController
 
@@ -27,8 +28,7 @@
 }
 
 - (void)vaultButtonTapped:(id)sender {
-    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-    VaultViewController *vaultVC = [[VaultViewController alloc] initWithCollectionViewLayout:layout];
+    VaultViewController *vaultVC = [[VaultViewController alloc] initWithStyle:UITableViewStyleGrouped];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vaultVC];
     navController.modalPresentationStyle = UIModalPresentationFullScreen;
     [self presentViewController:navController animated:YES completion:nil];
@@ -57,6 +57,84 @@
     } else {
         // no biometry
     }
+}
+
+- (void)enableEncryption {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Enable Encryption" message:@"Please enter a password for your vault." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = @"Password";
+        textField.secureTextEntry = YES;
+    }];
+    
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        UITextField *passwordField = alert.textFields.firstObject;
+        NSString *password = passwordField.text;
+        
+        if (password.length > 0) {
+            [self confirmPassword:password];
+        } else {
+            // show error
+        }
+    }];
+    
+    [alert addAction:okAction];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)confirmPassword:(NSString *)password {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Confirm Password" message:@"Please enter your password again." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = @"Password";
+        textField.secureTextEntry = YES;
+    }];
+    
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        UITextField *passwordField = alert.textFields.firstObject;
+        NSString *confirmedPassword = passwordField.text;
+        
+        if ([password isEqualToString:confirmedPassword]) {
+            [[VaultManager sharedManager] enableEncryptionWithPassword:password completion:^(BOOL success) {
+                if (success) {
+                    // show success
+                } else {
+                    // show error
+                }
+            }];
+        } else {
+            // show error
+        }
+    }];
+    
+    [alert addAction:okAction];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)disableEncryption {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Disable Encryption" message:@"Please enter your password to disable vault encryption." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = @"Password";
+        textField.secureTextEntry = YES;
+    }];
+    
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        UITextField *passwordField = alert.textFields.firstObject;
+        NSString *password = passwordField.text;
+        
+        if (password.length > 0) {
+            [[VaultManager sharedManager] disableEncryptionWithPassword:password completion:^(BOOL success) {
+                if (success) {
+                    // show success
+                } else {
+                    // show error
+                }
+            }];
+        } else {
+            // show error
+        }
+    }];
+    
+    [alert addAction:okAction];
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 @end

--- a/VaultContentTypesViewController.h
+++ b/VaultContentTypesViewController.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+#import "VaultMediaItem.h"
+
+@interface VaultContentTypesViewController : UITableViewController
+
+- (instancetype)initWithItems:(NSArray<VaultMediaItem *> *)items andUsername:(NSString *)username;
+
+@end

--- a/VaultContentTypesViewController.m
+++ b/VaultContentTypesViewController.m
@@ -1,0 +1,95 @@
+#import "VaultContentTypesViewController.h"
+#import "VaultItemsViewController.h"
+
+@interface VaultContentTypesViewController ()
+@property (nonatomic, strong) NSArray<VaultMediaItem *> *items;
+@property (nonatomic, strong) NSString *username;
+@property (nonatomic, strong) NSDictionary<NSNumber *, NSArray<VaultMediaItem *> *> *groupedItems;
+@property (nonatomic, strong) NSArray<NSNumber *> *sortedContentTypes;
+@end
+
+@implementation VaultContentTypesViewController
+
+- (instancetype)initWithItems:(NSArray<VaultMediaItem *> *)items andUsername:(NSString *)username {
+    self = [super initWithStyle:UITableViewStyleGrouped];
+    if (self) {
+        self.items = items;
+        self.username = username;
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = self.username;
+    
+    [self groupItems];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self groupItems];
+}
+
+- (void)groupItems {
+    NSMutableDictionary<NSNumber *, NSMutableArray<VaultMediaItem *> *> *grouped = [NSMutableDictionary dictionary];
+    for (VaultMediaItem *item in self.items) {
+        NSNumber *contentType = @(item.contentType);
+        NSMutableArray<VaultMediaItem *> *typeItems = grouped[contentType];
+        if (!typeItems) {
+            typeItems = [NSMutableArray array];
+            grouped[contentType] = typeItems;
+        }
+        [typeItems addObject:item];
+    }
+    self.groupedItems = grouped;
+    self.sortedContentTypes = [[self.groupedItems allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    [self.tableView reloadData];
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.sortedContentTypes.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell"];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    }
+    
+    NSNumber *contentTypeNumber = self.sortedContentTypes[indexPath.row];
+    VaultMediaItemType contentType = [contentTypeNumber unsignedIntegerValue];
+    
+    switch (contentType) {
+        case VaultMediaItemTypePhoto:
+            cell.textLabel.text = @"Photos";
+            break;
+        case VaultMediaItemTypeVideo:
+            cell.textLabel.text = @"Videos";
+            break;
+        case VaultMediaItemTypeAudio:
+            cell.textLabel.text = @"Audio";
+            break;
+    }
+    
+    return cell;
+}
+
+#pragma mark - Table view delegate
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSNumber *contentTypeNumber = self.sortedContentTypes[indexPath.row];
+    NSArray<VaultMediaItem *> *items = self.groupedItems[contentTypeNumber];
+    
+    VaultItemsViewController *itemsVC = [[VaultItemsViewController alloc] initWithItems:items];
+    [self.navigationController pushViewController:itemsVC animated:YES];
+}
+
+@end

--- a/VaultFileViewerViewController.h
+++ b/VaultFileViewerViewController.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface VaultFileViewerViewController : UITableViewController
+
+- (instancetype)initWithItems:(NSArray<id> *)items;
+
+@end

--- a/VaultFileViewerViewController.m
+++ b/VaultFileViewerViewController.m
@@ -1,0 +1,44 @@
+#import "VaultFileViewerViewController.h"
+
+@interface VaultFileViewerViewController ()
+@property (nonatomic, strong) NSArray<id> *items;
+@end
+
+@implementation VaultFileViewerViewController
+
+- (instancetype)initWithItems:(NSArray<id> *)items {
+    self = [super initWithStyle:UITableViewStyleGrouped];
+    if (self) {
+        self.items = items;
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Vault File Viewer";
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.items.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell"];
+    }
+    
+    id item = self.items[indexPath.row];
+    cell.textLabel.text = [item description];
+    
+    return cell;
+}
+
+@end

--- a/VaultItemsViewController.h
+++ b/VaultItemsViewController.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+#import "FilterViewController.h"
+#import "VaultMediaItem.h"
+
+@interface VaultItemsViewController : UICollectionViewController <UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate>
+
+- (instancetype)initWithItems:(NSArray<VaultMediaItem *> *)items;
+
+@end

--- a/VaultItemsViewController.m
+++ b/VaultItemsViewController.m
@@ -1,0 +1,191 @@
+#import "VaultItemsViewController.h"
+#import "VaultMediaItem.h"
+#import "VaultManager.h"
+#import "PhotoViewController.h"
+#import "FilterViewController.h"
+#import <AVKit/AVKit.h>
+#import <CommonCrypto/CommonCrypto.h>
+
+@interface VaultItemsViewController () <UIDocumentPickerDelegate>
+@property (nonatomic, strong) NSMutableArray<VaultMediaItem *> *items;
+@property (nonatomic, strong) NSDictionary *activeFilters;
+@property (nonatomic, strong) NSMutableArray<VaultMediaItem *> *selectedItems;
+@end
+
+@implementation VaultItemsViewController
+
+- (instancetype)initWithItems:(NSArray<VaultMediaItem *> *)items {
+    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+    self = [super initWithCollectionViewLayout:layout];
+    if (self) {
+        self.items = [items mutableCopy];
+        self.selectedItems = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Vault";
+    self.collectionView.backgroundColor = [UIColor systemBackgroundColor];
+    [self.collectionView registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:@"Cell"];
+    self.collectionView.allowsMultipleSelection = YES;
+    
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Select" style:UIBarButtonItemStylePlain target:self action:@selector(selectButtonTapped:)];
+    
+    [self loadItems];
+}
+
+- (void)loadItems {
+    // This will be initialized from the previous view controller
+    [self.collectionView reloadData];
+}
+
+- (void)selectButtonTapped:(id)sender {
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Cancel" style:UIBarButtonItemStylePlain target:self action:@selector(cancelButtonTapped:)];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Export" style:UIBarButtonItemStylePlain target:self action:@selector(exportButtonTapped:)];
+}
+
+- (void)cancelButtonTapped:(id)sender {
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Select" style:UIBarButtonItemStylePlain target:self action:@selector(selectButtonTapped:)];
+    self.navigationItem.leftBarButtonItem = nil;
+    [self.selectedItems removeAllObjects];
+    [self.collectionView reloadData];
+}
+
+- (void)exportButtonTapped:(id)sender {
+    [[VaultManager sharedManager] exportItemsToPhotoLibrary:self.selectedItems completion:^(BOOL success) {
+        if (success) {
+            [self.items removeObjectsInArray:self.selectedItems];
+            [self.selectedItems removeAllObjects];
+            [self.collectionView reloadData];
+            
+            if (self.items.count == 0) {
+                [self.navigationController popViewControllerAnimated:YES];
+            }
+        }
+    }];
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return self.items.count;
+}
+
+- (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
+    cell.backgroundColor = [UIColor lightGrayColor];
+    
+    VaultMediaItem *item = self.items[indexPath.item];
+    
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame:cell.contentView.bounds];
+    imageView.contentMode = UIViewContentModeScaleAspectFit;
+    imageView.clipsToBounds = YES;
+    [cell.contentView addSubview:imageView];
+    
+    if (item.contentType == VaultMediaItemTypePhoto) {
+        NSData *data = [NSData dataWithContentsOfFile:item.filePath];
+        if ([[VaultManager sharedManager] encryptionEnabled]) {
+            data = [[VaultManager sharedManager] crypt:data operation:kCCDecrypt];
+        }
+        imageView.image = [UIImage imageWithData:data];
+    } else if (item.contentType == VaultMediaItemTypeVideo) {
+        [self generateThumbnailForItem:item completion:^(UIImage *thumbnail) {
+            imageView.image = thumbnail;
+        }];
+    } else if (item.contentType == VaultMediaItemTypeAudio) {
+        imageView.image = [UIImage systemImageNamed:@"music.note"];
+    }
+    
+    if ([self.selectedItems containsObject:item]) {
+        cell.layer.borderColor = [UIColor blueColor].CGColor;
+        cell.layer.borderWidth = 2.0;
+    } else {
+        cell.layer.borderColor = [UIColor clearColor].CGColor;
+        cell.layer.borderWidth = 0.0;
+    }
+    
+    return cell;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    VaultMediaItem *item = self.items[indexPath.item];
+    
+    if (self.navigationItem.leftBarButtonItem) { // If in selection mode
+        if ([self.selectedItems containsObject:item]) {
+            [self.selectedItems removeObject:item];
+        } else {
+            [self.selectedItems addObject:item];
+        }
+        [self.collectionView reloadItemsAtIndexPaths:@[indexPath]];
+    } else {
+        NSData *data = [NSData dataWithContentsOfFile:item.filePath];
+        if ([[VaultManager sharedManager] encryptionEnabled]) {
+            data = [[VaultManager sharedManager] crypt:data operation:kCCDecrypt];
+        }
+        
+        NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:item.filePath.lastPathComponent];
+        [data writeToFile:tempPath atomically:YES];
+        NSURL *tempURL = [NSURL fileURLWithPath:tempPath];
+        
+        if (item.contentType == VaultMediaItemTypePhoto) {
+            PhotoViewController *photoVC = [[PhotoViewController alloc] initWithItems:self.items atIndex:indexPath.item];
+            [self.navigationController pushViewController:photoVC animated:YES];
+        } else if (item.contentType == VaultMediaItemTypeVideo) {
+            AVPlayer *player = [AVPlayer playerWithURL:tempURL];
+            AVPlayerViewController *playerViewController = [AVPlayerViewController new];
+            playerViewController.player = player;
+            [self presentViewController:playerViewController animated:YES completion:^{
+                [playerViewController.player play];
+            }];
+        } else if (item.contentType == VaultMediaItemTypeAudio) {
+            AVPlayer *player = [AVPlayer playerWithURL:tempURL];
+            AVPlayerViewController *playerViewController = [AVPlayerViewController new];
+            playerViewController.player = player;
+            [self presentViewController:playerViewController animated:YES completion:^{
+                [playerViewController.player play];
+            }];
+        }
+    }
+}
+
+- (void)generateThumbnailForItem:(VaultMediaItem *)item completion:(void (^)(UIImage *thumbnail))completion {
+    if (!completion) {
+        return;
+    }
+    
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSData *data = [NSData dataWithContentsOfFile:item.filePath];
+        if ([[VaultManager sharedManager] encryptionEnabled]) {
+            data = [[VaultManager sharedManager] crypt:data operation:kCCDecrypt];
+        }
+        
+        NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:item.filePath.lastPathComponent];
+        [data writeToFile:tempPath atomically:YES];
+        NSURL *tempURL = [NSURL fileURLWithPath:tempPath];
+        
+        AVURLAsset *asset = [AVURLAsset URLAssetWithURL:tempURL options:nil];
+        AVAssetImageGenerator *generator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
+        generator.appliesPreferredTrackTransform = YES;
+        
+        CMTime time = CMTimeMake(1, 1);
+        
+        NSError *error = nil;
+        CGImageRef imageRef = [generator copyCGImageAtTime:time actualTime:NULL error:&error];
+        
+        if (error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(nil);
+            });
+            return;
+        }
+        
+        UIImage *thumbnail = [UIImage imageWithCGImage:imageRef];
+        CGImageRelease(imageRef);
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(thumbnail);
+        });
+    });
+}
+
+@end

--- a/VaultManager.h
+++ b/VaultManager.h
@@ -1,17 +1,36 @@
 #import <Foundation/Foundation.h>
 #import "VaultMediaItem.h"
+#import <CommonCrypto/CommonCrypto.h>
 
 @interface VaultManager : NSObject
 
 + (instancetype)sharedManager;
+
+@property (nonatomic, assign, readonly) BOOL isLegacy;
+@property (nonatomic, strong, readonly) NSArray<VaultMediaItem *> *legacyItems;
+@property (nonatomic, assign, readonly) BOOL encryptionEnabled;
+@property (nonatomic, assign, readonly) BOOL isUnlocked;
+@property (nonatomic, strong, readonly) NSString *vaultPath;
 
 - (void)loadVaultItems;
 - (void)saveVaultItems;
 
 - (void)addVaultItem:(VaultMediaItem *)item;
 - (void)deleteVaultItem:(VaultMediaItem *)item;
+- (BOOL)isItemInVaultWithID:(NSString *)itemID;
+
+- (void)enableEncryptionWithPassword:(NSString *)password completion:(void (^)(BOOL success))completion;
+- (void)disableEncryptionWithPassword:(NSString *)password completion:(void (^)(BOOL success))completion;
+- (BOOL)unlockWithPassword:(NSString *)password;
 
 - (NSArray<VaultMediaItem *> *)allItems;
 - (NSArray<VaultMediaItem *> *)favoriteItems;
+- (NSDictionary<NSString *, NSArray<VaultMediaItem *> *> *)groupedItems;
+
+- (void)saveLegacyItemsToPhotosWithCompletion:(void (^)(BOOL success))completion;
+- (void)deleteLegacyVault;
+- (void)exportItemsToPhotoLibrary:(NSArray<VaultMediaItem *> *)items completion:(void (^)(BOOL success))completion;
+
+- (NSData *)crypt:(NSData *)data operation:(CCOperation)operation;
 
 @end

--- a/VaultManager.m
+++ b/VaultManager.m
@@ -1,11 +1,27 @@
 #import "VaultManager.h"
+#import <Photos/Photos.h>
+#import <CommonCrypto/CommonCrypto.h>
+#import "JGProgressHUD.h"
+
+#define kEncryptionKeySaltKey @"vault_encryption_salt"
+#define kVaultVersionKey @"vault_version"
+#define kVaultItemsKey @"vault_items"
 
 @interface VaultManager ()
 @property (nonatomic, strong) NSMutableArray<VaultMediaItem *> *items;
-@property (nonatomic, strong) NSString *vaultPath;
+@property (nonatomic, strong) NSArray<VaultMediaItem *> *legacyItems;
+@property (nonatomic, strong) NSData *encryptionKey;
+@property (nonatomic, assign) BOOL encryptionEnabled;
+@property (nonatomic, assign) BOOL isLegacy;
 @end
 
 @implementation VaultManager
+
+@synthesize legacyItems = _legacyItems;
+@synthesize encryptionEnabled = _encryptionEnabled;
+@synthesize isUnlocked = _unlocked;
+@synthesize isLegacy = _isLegacy;
+@synthesize vaultPath = _vaultPath;
 
 + (instancetype)sharedManager {
     static VaultManager *sharedManager = nil;
@@ -22,6 +38,7 @@
         _items = [NSMutableArray array];
         NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
         _vaultPath = [documentsDirectory stringByAppendingPathComponent:@"vault.dat"];
+        self.encryptionEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"vault_encryption_enabled"];
         [self loadVaultItems];
     }
     return self;
@@ -30,17 +47,48 @@
 - (void)loadVaultItems {
     NSData *data = [NSData dataWithContentsOfFile:self.vaultPath];
     if (data) {
-        NSSet *classes = [NSSet setWithArray:@[[NSMutableArray class], [VaultMediaItem class]]];
-        self.items = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:data error:nil];
+        if (self.encryptionEnabled && !self.isUnlocked) {
+            // Don't load items if the vault is locked
+            return;
+        }
+        
+        if (self.encryptionEnabled && self.encryptionKey) {
+            data = [self crypt:data operation:kCCDecrypt];
+        }
+        
+        id unarchivedObject = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:data error:nil];
+        if ([unarchivedObject isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *vaultDict = (NSDictionary *)unarchivedObject;
+            if (vaultDict[kVaultVersionKey]) {
+                self.items = [vaultDict[kVaultItemsKey] mutableCopy];
+                self.isLegacy = NO;
+            } else {
+                // This should not happen with the new structure
+                self.legacyItems = (NSArray *)unarchivedObject;
+                self.isLegacy = YES;
+            }
+        } else if ([unarchivedObject isKindOfClass:[NSArray class]]) {
+            self.legacyItems = unarchivedObject;
+            self.isLegacy = YES;
+        }
     }
 }
 
 - (void)saveVaultItems {
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.items requiringSecureCoding:YES error:nil];
+    NSDictionary *vaultDict = @{kVaultVersionKey: @2, kVaultItemsKey: self.items};
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:vaultDict requiringSecureCoding:YES error:nil];
+    if (self.encryptionEnabled && self.encryptionKey) {
+        data = [self crypt:data operation:kCCEncrypt];
+    }
     [data writeToFile:self.vaultPath atomically:YES];
 }
 
 - (void)addVaultItem:(VaultMediaItem *)item {
+    if (self.encryptionEnabled && self.encryptionKey) {
+        NSData *fileData = [NSData dataWithContentsOfFile:item.filePath];
+        NSData *encryptedData = [self crypt:fileData operation:kCCEncrypt];
+        [encryptedData writeToFile:item.filePath atomically:YES];
+    }
     [self.items addObject:item];
     [self saveVaultItems];
 }
@@ -58,6 +106,237 @@
 - (NSArray<VaultMediaItem *> *)favoriteItems {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"isFavorite == YES"];
     return [self.items filteredArrayUsingPredicate:predicate];
+}
+
+- (BOOL)isItemInVaultWithID:(NSString *)itemID {
+    for (VaultMediaItem *item in self.items) {
+        if ([item.internalID isEqualToString:itemID]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (NSDictionary<NSString *, NSArray<VaultMediaItem *> *> *)groupedItems {
+    NSMutableDictionary<NSString *, NSMutableArray<VaultMediaItem *> *> *grouped = [NSMutableDictionary dictionary];
+    for (VaultMediaItem *item in self.items) {
+        NSString *creator = item.creatorUsername;
+        if (creator) {
+            NSMutableArray<VaultMediaItem *> *userItems = grouped[creator];
+            if (!userItems) {
+                userItems = [NSMutableArray array];
+                grouped[creator] = userItems;
+            }
+            [userItems addObject:item];
+        }
+    }
+    return grouped;
+}
+
+- (void)saveLegacyItemsToPhotosWithCompletion:(void (^)(BOOL success))completion {
+    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+        for (VaultMediaItem *item in self.legacyItems) {
+            if (item.contentType == VaultMediaItemTypeVideo) {
+                [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:[NSURL fileURLWithPath:item.filePath]];
+            } else if (item.contentType == VaultMediaItemTypePhoto) {
+                [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:[NSURL fileURLWithPath:item.filePath]];
+            }
+        }
+    } completionHandler:^(BOOL success, NSError * _Nullable error) {
+        if (success) {
+            [self deleteLegacyVault];
+        }
+        if (completion) {
+            completion(success);
+        }
+    }];
+}
+
+- (void)deleteLegacyVault {
+    self.legacyItems = nil;
+    self.isLegacy = NO;
+    [[NSFileManager defaultManager] removeItemAtPath:self.vaultPath error:nil];
+}
+
+- (void)exportItemsToPhotoLibrary:(NSArray<VaultMediaItem *> *)items completion:(void (^)(BOOL))completion {
+    UIImpactFeedbackGenerator *feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
+    [feedbackGenerator impactOccurred];
+    
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+            for (VaultMediaItem *item in items) {
+                NSData *data = [NSData dataWithContentsOfFile:item.filePath];
+                if (self.encryptionEnabled) {
+                    data = [self crypt:data operation:kCCDecrypt];
+                }
+                
+                NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:item.filePath.lastPathComponent];
+                [data writeToURL:[NSURL fileURLWithPath:tempPath] atomically:YES];
+                
+                if (item.contentType == VaultMediaItemTypeVideo) {
+                    [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:[NSURL fileURLWithPath:tempPath]];
+                } else if (item.contentType == VaultMediaItemTypePhoto) {
+                    [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:[NSURL fileURLWithPath:tempPath]];
+                }
+            }
+        } completionHandler:^(BOOL success, NSError * _Nullable error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (success) {
+                    for (VaultMediaItem *item in items) {
+                        [self deleteVaultItem:item];
+                    }
+                }
+                if (completion) {
+                    completion(success);
+                }
+            });
+        }];
+    });
+}
+
+#pragma mark - Encryption
+
+- (void)processAllFilesWithOperation:(CCOperation)operation withHUD:(JGProgressHUD *)hud completion:(void (^)(BOOL))completion {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        float totalFiles = self.items.count;
+        float processedFiles = 0;
+        
+        for (VaultMediaItem *item in self.items) {
+            NSData *fileData = [NSData dataWithContentsOfFile:item.filePath];
+            NSData *processedData = [self crypt:fileData operation:operation];
+            [processedData writeToFile:item.filePath atomically:YES];
+            
+            processedFiles++;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                hud.progress = processedFiles / totalFiles;
+            });
+        }
+        
+        if (completion) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(YES);
+            });
+        }
+    });
+}
+
+- (void)enableEncryptionWithPassword:(NSString *)password completion:(void (^)(BOOL success))completion {
+    UIImpactFeedbackGenerator *feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
+    [feedbackGenerator impactOccurred];
+    
+    JGProgressHUD *hud = [JGProgressHUD progressHUDWithStyle:JGProgressHUDStyleDark];
+    hud.textLabel.text = @"Encrypting...";
+    [hud showInView:[[[UIApplication sharedApplication] keyWindow] rootViewController].view];
+    
+    NSData *salt = [self generateSalt];
+    [[NSUserDefaults standardUserDefaults] setObject:salt forKey:kEncryptionKeySaltKey];
+    self.encryptionKey = [self deriveKeyFromPassword:password salt:salt];
+    _encryptionEnabled = YES;
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"vault_encryption_enabled"];
+    [self processAllFilesWithOperation:kCCEncrypt withHUD:hud completion:^(BOOL success) {
+        [self saveVaultItems];
+        _unlocked = YES;
+        [hud dismiss];
+        if (completion) {
+            completion(YES);
+        }
+    }];
+}
+
+- (void)disableEncryptionWithPassword:(NSString *)password completion:(void (^)(BOOL success))completion {
+    UIImpactFeedbackGenerator *feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
+    [feedbackGenerator impactOccurred];
+    
+    JGProgressHUD *hud = [JGProgressHUD progressHUDWithStyle:JGProgressHUDStyleDark];
+    hud.textLabel.text = @"Decrypting...";
+    [hud showInView:[[[UIApplication sharedApplication] keyWindow] rootViewController].view];
+    
+    NSData *salt = [[NSUserDefaults standardUserDefaults] objectForKey:kEncryptionKeySaltKey];
+    NSData *key = [self deriveKeyFromPassword:password salt:salt];
+    
+    NSData *vaultData = [NSData dataWithContentsOfFile:self.vaultPath];
+    NSData *decryptedData = [self crypt:vaultData operation:kCCDecrypt withKey:key];
+
+    if (decryptedData) {
+        self.encryptionKey = key;
+        [self processAllFilesWithOperation:kCCDecrypt withHUD:hud completion:^(BOOL success) {
+            _encryptionEnabled = NO;
+            self.encryptionKey = nil;
+            _unlocked = NO;
+            [[NSUserDefaults standardUserDefaults] removeObjectForKey:kEncryptionKeySaltKey];
+            [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"vault_encryption_enabled"];
+            [self saveVaultItems];
+            [hud dismiss];
+            if (completion) {
+                completion(YES);
+            }
+        }];
+    } else {
+        [hud dismiss];
+        if (completion) {
+            completion(NO);
+        }
+    }
+}
+
+- (BOOL)unlockWithPassword:(NSString *)password {
+    NSData *salt = [[NSUserDefaults standardUserDefaults] objectForKey:kEncryptionKeySaltKey];
+    NSData *key = [self deriveKeyFromPassword:password salt:salt];
+    
+    NSData *vaultData = [NSData dataWithContentsOfFile:self.vaultPath];
+    NSData *decryptedData = [self crypt:vaultData operation:kCCDecrypt withKey:key];
+    
+    if (decryptedData) {
+        id unarchivedObject = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:decryptedData error:nil];
+        if (unarchivedObject) {
+            self.encryptionKey = key;
+            _unlocked = YES;
+            [self loadVaultItems];
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
+- (NSData *)deriveKeyFromPassword:(NSString *)password salt:(NSData *)salt {
+    uint8_t derivedKey[kCCKeySizeAES256];
+    CCKeyDerivationPBKDF(kCCPBKDF2, [password UTF8String], password.length, [salt bytes], salt.length, kCCPRFHmacAlgSHA256, 10000, derivedKey, kCCKeySizeAES256);
+    return [NSData dataWithBytes:derivedKey length:kCCKeySizeAES256];
+}
+
+- (NSData *)generateSalt {
+    uint8_t salt[8];
+    int status = SecRandomCopyBytes(kSecRandomDefault, 8, salt);
+    if (status == errSecSuccess) {
+        return [NSData dataWithBytes:salt length:8];
+    }
+    return nil;
+}
+
+- (NSData *)crypt:(NSData *)data operation:(CCOperation)operation {
+    return [self crypt:data operation:operation withKey:self.encryptionKey];
+}
+
+- (NSData *)crypt:(NSData *)data operation:(CCOperation)operation withKey:(NSData *)key {
+    char keyPtr[kCCKeySizeAES256 + 1];
+    bzero(keyPtr, sizeof(keyPtr));
+    [key getBytes:keyPtr length:sizeof(keyPtr)];
+    
+    NSUInteger dataLength = [data length];
+    
+    size_t bufferSize = dataLength + kCCBlockSizeAES128;
+    void *buffer = malloc(bufferSize);
+    
+    size_t numBytesCrypted = 0;
+    CCCryptorStatus cryptStatus = CCCrypt(operation, kCCAlgorithmAES128, kCCOptionPKCS7Padding, keyPtr, kCCKeySizeAES256, NULL, [data bytes], dataLength, buffer, bufferSize, &numBytesCrypted);
+    
+    if (cryptStatus == kCCSuccess) {
+        return [NSData dataWithBytesNoCopy:buffer length:numBytesCrypted];
+    }
+    
+    free(buffer);
+    return nil;
 }
 
 @end

--- a/VaultMediaItem.h
+++ b/VaultMediaItem.h
@@ -2,7 +2,8 @@
 
 typedef NS_ENUM(NSInteger, VaultMediaItemType) {
     VaultMediaItemTypePhoto,
-    VaultMediaItemTypeVideo
+    VaultMediaItemTypeVideo,
+    VaultMediaItemTypeAudio
 };
 
 @interface VaultMediaItem : NSObject <NSSecureCoding>

--- a/VaultStatsViewController.h
+++ b/VaultStatsViewController.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface VaultStatsViewController : UIViewController
+
+@end

--- a/VaultStatsViewController.m
+++ b/VaultStatsViewController.m
@@ -1,0 +1,205 @@
+#import "VaultStatsViewController.h"
+#import "VaultManager.h"
+#import "VaultFileViewerViewController.h"
+
+@interface VaultStatsViewController () <UITableViewDataSource, UITableViewDelegate>
+
+@property (nonatomic, strong) UIView *barChartView;
+@property (nonatomic, strong) UILabel *totalSizeLabel;
+@property (nonatomic, strong) UILabel *videoSizeLabel;
+@property (nonatomic, strong) UILabel *photoSizeLabel;
+@property (nonatomic, strong) UILabel *audioSizeLabel;
+@property (nonatomic, strong) UILabel *vaultPathLabel;
+@property (nonatomic, strong) UIView *encryptionStatusView;
+@property (nonatomic, strong) UITableView *filesTableView;
+@property (nonatomic, strong) NSArray<NSString *> *datFiles;
+
+@end
+
+@implementation VaultStatsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Vault Stats";
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
+    
+    [self setupViews];
+    [self updateStats];
+    [self findDatFiles];
+}
+
+- (void)setupViews {
+    self.barChartView = [[UIView alloc] initWithFrame:CGRectMake(20, 100, self.view.bounds.size.width - 40, 200)];
+    [self.view addSubview:self.barChartView];
+    
+    self.totalSizeLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 320, self.view.bounds.size.width - 40, 20)];
+    [self.view addSubview:self.totalSizeLabel];
+    
+    self.videoSizeLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 350, self.view.bounds.size.width - 40, 20)];
+    [self.view addSubview:self.videoSizeLabel];
+    
+    self.photoSizeLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 380, self.view.bounds.size.width - 40, 20)];
+    [self.view addSubview:self.photoSizeLabel];
+    
+    self.audioSizeLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 410, self.view.bounds.size.width - 40, 20)];
+    [self.view addSubview:self.audioSizeLabel];
+    
+    self.vaultPathLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 440, self.view.bounds.size.width - 40, 20)];
+    [self.view addSubview:self.vaultPathLabel];
+    
+    self.encryptionStatusView = [[UIView alloc] initWithFrame:CGRectMake(20, 470, 20, 20)];
+    self.encryptionStatusView.layer.cornerRadius = 10;
+    [self.view addSubview:self.encryptionStatusView];
+    
+    self.filesTableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 500, self.view.bounds.size.width, self.view.bounds.size.height - 500) style:UITableViewStyleGrouped];
+    self.filesTableView.dataSource = self;
+    self.filesTableView.delegate = self;
+    [self.view addSubview:self.filesTableView];
+}
+
+- (void)updateStats {
+    NSArray<VaultMediaItem *> *items = [[VaultManager sharedManager] allItems];
+    
+    long long totalSize = 0;
+    long long videoSize = 0;
+    long long photoSize = 0;
+    long long audioSize = 0;
+    
+    for (VaultMediaItem *item in items) {
+        long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:item.filePath error:nil] fileSize];
+        totalSize += fileSize;
+        
+        switch (item.contentType) {
+            case VaultMediaItemTypeVideo:
+                videoSize += fileSize;
+                break;
+            case VaultMediaItemTypePhoto:
+                photoSize += fileSize;
+                break;
+            case VaultMediaItemTypeAudio:
+                audioSize += fileSize;
+                break;
+        }
+    }
+    
+    self.totalSizeLabel.text = [NSString stringWithFormat:@"Total Size: %@", [NSByteCountFormatter stringFromByteCount:totalSize countStyle:NSByteCountFormatterCountStyleFile]];
+    self.videoSizeLabel.text = [NSString stringWithFormat:@"Video Size: %@", [NSByteCountFormatter stringFromByteCount:videoSize countStyle:NSByteCountFormatterCountStyleFile]];
+    self.photoSizeLabel.text = [NSString stringWithFormat:@"Photo Size: %@", [NSByteCountFormatter stringFromByteCount:photoSize countStyle:NSByteCountFormatterCountStyleFile]];
+    self.audioSizeLabel.text = [NSString stringWithFormat:@"Audio Size: %@", [NSByteCountFormatter stringFromByteCount:audioSize countStyle:NSByteCountFormatterCountStyleFile]];
+    
+    self.vaultPathLabel.text = [NSString stringWithFormat:@"Vault Path: %@", [[VaultManager sharedManager] vaultPath]];
+    
+    if ([[VaultManager sharedManager] encryptionEnabled]) {
+        self.encryptionStatusView.backgroundColor = [UIColor greenColor];
+    } else {
+        self.encryptionStatusView.backgroundColor = [UIColor redColor];
+    }
+    
+    [self drawBarChartWithVideoSize:videoSize photoSize:photoSize audioSize:audioSize totalSize:totalSize];
+}
+
+- (void)drawBarChartWithVideoSize:(long long)videoSize photoSize:(long long)photoSize audioSize:(long long)audioSize totalSize:(long long)totalSize {
+    for (UIView *subview in self.barChartView.subviews) {
+        [subview removeFromSuperview];
+    }
+    
+    if (totalSize == 0) {
+        return;
+    }
+    
+    CGFloat videoHeight = (CGFloat)videoSize / totalSize * 200;
+    CGFloat photoHeight = (CGFloat)photoSize / totalSize * 200;
+    CGFloat audioHeight = (CGFloat)audioSize / totalSize * 200;
+    
+    UIView *videoBar = [[UIView alloc] initWithFrame:CGRectMake(0, 200 - videoHeight, 50, videoHeight)];
+    videoBar.backgroundColor = [UIColor blueColor];
+    [self.barChartView addSubview:videoBar];
+    
+    UIView *photoBar = [[UIView alloc] initWithFrame:CGRectMake(70, 200 - photoHeight, 50, photoHeight)];
+    photoBar.backgroundColor = [UIColor greenColor];
+    [self.barChartView addSubview:photoBar];
+    
+    UIView *audioBar = [[UIView alloc] initWithFrame:CGRectMake(140, 200 - audioHeight, 50, audioHeight)];
+    audioBar.backgroundColor = [UIColor orangeColor];
+    [self.barChartView addSubview:audioBar];
+}
+
+- (void)findDatFiles {
+    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+    NSArray *allFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:documentsDirectory error:nil];
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"self ENDSWITH '.dat'"];
+    self.datFiles = [allFiles filteredArrayUsingPredicate:predicate];
+    
+    [self.filesTableView reloadData];
+}
+
+#pragma mark - UITableViewDataSource
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.datFiles.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell"];
+    }
+    
+    NSString *fileName = self.datFiles[indexPath.row];
+    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:fileName];
+    
+    long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil] fileSize];
+    cell.detailTextLabel.text = [NSByteCountFormatter stringFromByteCount:fileSize countStyle:NSByteCountFormatterCountStyleFile];
+    
+    NSData *data = [NSData dataWithContentsOfFile:filePath];
+    id unarchivedObject = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:data error:nil];
+    
+    if (unarchivedObject) {
+        cell.imageView.image = [UIImage systemImageNamed:@"lock.open.fill"];
+    } else {
+        cell.imageView.image = [UIImage systemImageNamed:@"lock.fill"];
+    }
+    
+    if ([filePath isEqualToString:[[VaultManager sharedManager] vaultPath]]) {
+        cell.textLabel.text = [NSString stringWithFormat:@"Loaded: %@", fileName];
+        cell.backgroundColor = [UIColor systemGreenColor];
+    } else {
+        cell.textLabel.text = fileName;
+        cell.backgroundColor = [UIColor systemBackgroundColor];
+    }
+    
+    return cell;
+}
+
+#pragma mark - UITableViewDelegate
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSString *fileName = self.datFiles[indexPath.row];
+    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+    NSString *filePath = [documentsDirectory stringByAppendingPathComponent:fileName];
+
+    if ([filePath isEqualToString:[[VaultManager sharedManager] vaultPath]]) {
+        return nil;
+    }
+
+    UIContextualAction *deleteAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:@"Delete" handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Delete Vault File" message:[NSString stringWithFormat:@"Are you sure you want to delete %@?", fileName] preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
+            [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+            [self findDatFiles];
+        }]];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alert animated:YES completion:nil];
+        completionHandler(YES);
+    }];
+
+    return [UISwipeActionsConfiguration configurationWithActions:@[deleteAction]];
+}
+
+@end

--- a/VaultViewController.h
+++ b/VaultViewController.h
@@ -1,6 +1,5 @@
 #import <UIKit/UIKit.h>
-#import "CreatorFilterViewController.h"
 
-@interface VaultViewController : UICollectionViewController
+@interface VaultViewController : UITableViewController
 
 @end

--- a/VaultViewController.m
+++ b/VaultViewController.m
@@ -1,400 +1,145 @@
 #import "VaultViewController.h"
 #import "VaultManager.h"
-#import "VaultMediaItem.h"
-#import <AVFoundation/AVFoundation.h>
-#import "PhotoViewController.h"
-#import "FilterViewController.h"
-#import <Photos/Photos.h>
+#import "VaultContentTypesViewController.h"
+#import "VaultStatsViewController.h"
 
-@interface VaultViewController () <UICollectionViewDelegateFlowLayout, FilterViewControllerDelegate, UIGestureRecognizerDelegate>
-
-@property (nonatomic, strong) NSArray<VaultMediaItem *> *items;
-@property (nonatomic, strong) NSDictionary *activeFilters;
-@property (nonatomic, assign) BOOL isSelectionMode;
-@property (nonatomic, strong) CAGradientLayer *rainbowLayer;
-@property (nonatomic, assign) BOOL initialSelectionState;
-@property (nonatomic, strong) NSIndexPath *lastSelectedIndexPath;
-@property (nonatomic, strong) UILongPressGestureRecognizer *longPressGesture;
-
+@interface VaultViewController ()
+@property (nonatomic, strong) NSDictionary<NSString *, NSArray<VaultMediaItem *> *> *groupedItems;
+@property (nonatomic, strong) NSArray<NSString *> *sortedUsernames;
 @end
 
 @implementation VaultViewController
 
-static NSString * const reuseIdentifier = @"VaultCell";
-
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
-    self.title = @"Vault";
-    self.collectionView.backgroundColor = [UIColor systemBackgroundColor];
-
-    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionViewLayout;
-    layout.minimumInteritemSpacing = 4;
-    layout.minimumLineSpacing = 4;
-    CGFloat size = (self.view.frame.size.width - layout.minimumInteritemSpacing * 3) / 4;
-    layout.itemSize = CGSizeMake(size, size);
-    
-    [self.collectionView registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:reuseIdentifier];
-    
+    self.title = @"Media Vault";
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(done)];
-
-    UIBarButtonItem *exportButton = [[UIBarButtonItem alloc] initWithTitle:@"Export" style:UIBarButtonItemStylePlain target:self action:@selector(exportButtonTapped:)];
-    UIBarButtonItem *filterButton = [[UIBarButtonItem alloc] initWithTitle:@"Filter" style:UIBarButtonItemStylePlain target:self action:@selector(filterButtonTapped:)];
-    self.navigationItem.rightBarButtonItems = @[self.navigationItem.rightBarButtonItem, exportButton, filterButton];
-
-    self.longPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
-    [self.collectionView addGestureRecognizer:self.longPressGesture];
-    
-    [self loadItems];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Stats" style:UIBarButtonItemStylePlain target:self action:@selector(showStats)];
 }
 
-- (void)loadItems {
-    NSArray<VaultMediaItem *> *allItems = [[VaultManager sharedManager] allItems];
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
     
-    if (self.activeFilters) {
-        NSMutableArray *predicates = [NSMutableArray array];
-        
-        NSNumber *showFavorites = self.activeFilters[@"showFavorites"];
-        if (showFavorites && [showFavorites boolValue]) {
-            [predicates addObject:[NSPredicate predicateWithFormat:@"isFavorite == YES"]];
-        }
-        
-        NSNumber *contentType = self.activeFilters[@"contentType"];
-        if (contentType && [contentType integerValue] != 0) {
-            [predicates addObject:[NSPredicate predicateWithFormat:@"contentType == %d", ([contentType integerValue] == 1) ? VaultMediaItemTypePhoto : VaultMediaItemTypeVideo]];
-        }
-        
-        NSArray *creators = self.activeFilters[@"creators"];
-        if (creators && creators.count > 0) {
-            [predicates addObject:[NSPredicate predicateWithFormat:@"creatorUsername IN %@", creators]];
-        }
-        
-        if (predicates.count > 0) {
-            NSCompoundPredicate *compoundPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:predicates];
-            self.items = [allItems filteredArrayUsingPredicate:compoundPredicate];
+    if ([[VaultManager sharedManager] encryptionEnabled] && ![[VaultManager sharedManager] isUnlocked]) {
+        [self promptForPassword];
+    } else {
+        [self loadData];
+        [self showLegacyVaultAlertIfNeeded];
+    }
+}
+
+- (void)promptForPassword {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Vault Locked" message:@"Please enter your password to unlock the vault." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = @"Password";
+        textField.secureTextEntry = YES;
+    }];
+    
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        UITextField *passwordField = alert.textFields.firstObject;
+        if ([[VaultManager sharedManager] unlockWithPassword:passwordField.text]) {
+            [self loadData];
+            [self showLegacyVaultAlertIfNeeded];
         } else {
-            self.items = allItems;
+            [self shakeTextField:passwordField];
+            alert.message = @"Incorrect Password. Please try again.";
+            [self presentViewController:alert animated:YES completion:nil];
         }
-    } else {
-        self.items = allItems;
-    }
+    }];
     
-    [self.collectionView reloadData];
-}
-
-- (void)done {
-    if (self.isSelectionMode) {
-        for (NSIndexPath *indexPath in self.collectionView.indexPathsForSelectedItems) {
-            VaultMediaItem *item = self.items[indexPath.item];
-            [self exportItem:item];
-        }
-        [self cancelSelectionMode];
-    } else {
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
         [self dismissViewControllerAnimated:YES completion:nil];
-    }
-}
-
-- (void)filterButtonTapped:(id)sender {
-    FilterViewController *filterVC = [[FilterViewController alloc] init];
-    filterVC.delegate = self;
-    filterVC.selectedFilters = self.activeFilters;
+    }];
     
-    NSMutableSet *creatorSet = [NSMutableSet set];
-    for (VaultMediaItem *item in [[VaultManager sharedManager] allItems]) {
-        if (item.creatorUsername) {
-            [creatorSet addObject:item.creatorUsername];
-        }
-    }
-    filterVC.allCreators = [creatorSet allObjects];
-    
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:filterVC];
-    [self presentViewController:navController animated:YES completion:nil];
-}
-
-- (void)didApplyFilters:(NSDictionary *)filters {
-    self.activeFilters = filters;
-    [self loadItems];
-}
-
-- (void)exportButtonTapped:(id)sender {
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Export" message:nil preferredStyle:UIAlertControllerStyleActionSheet];
-
-    [alert addAction:[UIAlertAction actionWithTitle:@"Export Selected" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        self.isSelectionMode = YES;
-        self.collectionView.allowsMultipleSelection = YES;
-        self.navigationItem.rightBarButtonItems[0].title = @"Save";
-        [self addRainbowToButton:self.navigationItem.rightBarButtonItems[0]];
-        self.navigationItem.rightBarButtonItems[1].enabled = NO;
-        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Cancel" style:UIBarButtonItemStylePlain target:self action:@selector(cancelSelectionMode)];
-    }]];
-
-    [alert addAction:[UIAlertAction actionWithTitle:@"Export All" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        for (VaultMediaItem *item in self.items) {
-            [self exportItem:item];
-        }
-    }]];
-
-    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-
+    [alert addAction:okAction];
+    [alert addAction:cancelAction];
     [self presentViewController:alert animated:YES completion:nil];
 }
 
-- (void)cancelSelectionMode {
-    self.isSelectionMode = NO;
-    self.collectionView.allowsMultipleSelection = NO;
-    [self.collectionView reloadData];
-    
-    self.navigationItem.rightBarButtonItems[0].title = @"Done";
-    [self removeRainbowFromButton:self.navigationItem.rightBarButtonItems[0]];
-    self.navigationItem.rightBarButtonItems[1].enabled = YES;
-    
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Filter" style:UIBarButtonItemStylePlain target:self action:@selector(filterButtonTapped:)];
+- (void)shakeTextField:(UITextField *)textField {
+    CABasicAnimation *shake = [CABasicAnimation animationWithKeyPath:@"position"];
+    [shake setDuration:0.1];
+    [shake setRepeatCount:2];
+    [shake setAutoreverses:YES];
+    [shake setFromValue:[NSValue valueWithCGPoint:
+                         CGPointMake(textField.center.x - 5, textField.center.y)]];
+    [shake setToValue:[NSValue valueWithCGPoint:
+                       CGPointMake(textField.center.x + 5, textField.center.y)]];
+    [textField.layer addAnimation:shake forKey:@"position"];
 }
 
-- (void)exportItem:(VaultMediaItem *)item {
-    [self getOrCreateAlbumWithTitle:@"plusTikTok" completion:^(PHAssetCollection *album) {
-        if (album) {
-            [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-                PHAssetChangeRequest *changeRequest;
-                if (item.contentType == VaultMediaItemTypePhoto) {
-                    changeRequest = [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:[NSURL fileURLWithPath:item.filePath]];
-                } else {
-                    changeRequest = [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:[NSURL fileURLWithPath:item.filePath]];
+- (void)loadData {
+    self.groupedItems = [[VaultManager sharedManager] groupedItems];
+    self.sortedUsernames = [[self.groupedItems allKeys] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+    [self.tableView reloadData];
+}
+
+- (void)done {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)showStats {
+    VaultStatsViewController *statsVC = [[VaultStatsViewController alloc] init];
+    [self.navigationController pushViewController:statsVC animated:YES];
+}
+
+- (void)showLegacyVaultAlertIfNeeded {
+    if ([[VaultManager sharedManager] isLegacy]) {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Legacy Vault Found" message:@"We found an old vault file. Do you want to save the content to your photo library or delete it?" preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction *saveAction = [UIAlertAction actionWithTitle:@"Save All to Photos" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            [[VaultManager sharedManager] saveLegacyItemsToPhotosWithCompletion:^(BOOL success) {
+                if (success) {
+                    // Optional: Show a success message
                 }
-                PHAssetCollectionChangeRequest *albumChangeRequest = [PHAssetCollectionChangeRequest changeRequestForAssetCollection:album];
-                [albumChangeRequest addAssets:@[changeRequest.placeholderForCreatedAsset]];
-            } completionHandler:nil];
-        }
-    }];
-}
-
-- (void)getOrCreateAlbumWithTitle:(NSString *)title completion:(void (^)(PHAssetCollection *))completion {
-    PHFetchOptions *fetchOptions = [PHFetchOptions new];
-    fetchOptions.predicate = [NSPredicate predicateWithFormat:@"title = %@", title];
-    PHFetchResult *fetchResult = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum subtype:PHAssetCollectionSubtypeAny options:fetchOptions];
-    if (fetchResult.firstObject) {
-        completion(fetchResult.firstObject);
-    } else {
-        __block PHObjectPlaceholder *placeholder;
-        [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-            PHAssetCollectionChangeRequest *changeRequest = [PHAssetCollectionChangeRequest creationRequestForAssetCollectionWithTitle:title];
-            placeholder = changeRequest.placeholderForCreatedAssetCollection;
-        } completionHandler:^(BOOL success, NSError * _Nullable error) {
-            if (success) {
-                PHFetchResult *result = [PHAssetCollection fetchAssetCollectionsWithLocalIdentifiers:@[placeholder.localIdentifier] options:nil];
-                completion(result.firstObject);
-            } else {
-                completion(nil);
-            }
+            }];
         }];
+        
+        UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
+            [[VaultManager sharedManager] deleteLegacyVault];
+        }];
+        
+        UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+        
+        [alert addAction:saveAction];
+        [alert addAction:deleteAction];
+        [alert addAction:cancelAction];
+        
+        [self presentViewController:alert animated:YES completion:nil];
     }
 }
 
-- (void)addRainbowToButton:(UIBarButtonItem *)button {
-    UIView *view = [button valueForKey:@"view"];
-    UILabel *label = [view.subviews firstObject];
+#pragma mark - Table view data source
 
-    self.rainbowLayer = [CAGradientLayer layer];
-    self.rainbowLayer.frame = label.bounds;
-    self.rainbowLayer.colors = @[
-        (id)[UIColor redColor].CGColor,
-        (id)[UIColor orangeColor].CGColor,
-        (id)[UIColor yellowColor].CGColor,
-        (id)[UIColor greenColor].CGColor,
-        (id)[UIColor blueColor].CGColor,
-        (id)[UIColor purpleColor].CGColor
-    ];
-    self.rainbowLayer.startPoint = CGPointMake(0.0, 0.5);
-    self.rainbowLayer.endPoint = CGPointMake(1.0, 0.5);
-
-    label.layer.mask = self.rainbowLayer;
-
-    CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"colors"];
-    animation.fromValue = self.rainbowLayer.colors;
-    NSMutableArray *toColors = [self.rainbowLayer.colors mutableCopy];
-    [toColors addObject:[toColors firstObject]];
-    [toColors removeObjectAtIndex:0];
-    animation.toValue = toColors;
-    animation.duration = 1.0;
-    animation.repeatCount = HUGE_VALF;
-    [self.rainbowLayer addAnimation:animation forKey:@"rainbow"];
-}
-
-- (void)removeRainbowFromButton:(UIBarButtonItem *)button {
-    UIView *view = [button valueForKey:@"view"];
-    UILabel *label = [view.subviews firstObject];
-    [self.rainbowLayer removeAllAnimations];
-    label.layer.mask = nil;
-    self.rainbowLayer = nil;
-}
-
-
-#pragma mark <UICollectionViewDataSource>
-
-- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
     return 1;
 }
 
-
-- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
-    return self.items.count;
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.sortedUsernames.count;
 }
 
-- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
-    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:reuseIdentifier forIndexPath:indexPath];
-    
-    VaultMediaItem *item = self.items[indexPath.item];
-    
-    // Clear previous content
-    for (UIView *subview in cell.contentView.subviews) {
-        [subview removeFromSuperview];
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"Cell"];
+        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     }
     
-    UIImageView *imageView = [[UIImageView alloc] initWithFrame:cell.contentView.bounds];
-    imageView.contentMode = UIViewContentModeScaleAspectFill;
-    imageView.clipsToBounds = YES;
+    NSString *username = self.sortedUsernames[indexPath.row];
+    cell.textLabel.text = username;
     
-    if (item.contentType == VaultMediaItemTypePhoto) {
-        imageView.image = [UIImage imageWithContentsOfFile:item.filePath];
-    } else {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            UIImage *thumbnail = [self generateThumbnailForVideoAtURL:[NSURL fileURLWithPath:item.filePath]];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                imageView.image = thumbnail;
-            });
-        });
-    }
-    
-    [cell.contentView addSubview:imageView];
-
-    if (item.isFavorite) {
-        UIImageView *starView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"star.fill"]];
-        starView.frame = CGRectMake(cell.contentView.bounds.size.width - 24, 4, 20, 20);
-        starView.tintColor = [UIColor yellowColor];
-        [cell.contentView addSubview:starView];
-    }
-
-    if (self.isSelectionMode) {
-        UIImageView *checkmarkView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"checkmark.circle.fill"]];
-        checkmarkView.frame = CGRectMake(cell.contentView.bounds.size.width - 24, cell.contentView.bounds.size.height - 24, 20, 20);
-        checkmarkView.tintColor = [UIColor whiteColor];
-        checkmarkView.hidden = ![self.collectionView.indexPathsForSelectedItems containsObject:indexPath];
-        checkmarkView.tag = 100;
-        [cell.contentView addSubview:checkmarkView];
-    }
-
-    if ([self.collectionView.indexPathsForSelectedItems containsObject:indexPath]) {
-        cell.backgroundColor = [UIColor systemBlueColor];
-    } else {
-        cell.backgroundColor = [UIColor clearColor];
-    }
-
     return cell;
 }
 
-- (UIImage *)generateThumbnailForVideoAtURL:(NSURL *)url {
-    AVAsset *asset = [AVAsset assetWithURL:url];
-    AVAssetImageGenerator *generator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
-    generator.appliesPreferredTrackTransform = YES;
-    CMTime time = CMTimeMake(1, 60);
-    NSError *error = nil;
-    CGImageRef imageRef = [generator copyCGImageAtTime:time actualTime:NULL error:&error];
-    UIImage *thumbnail = [UIImage imageWithCGImage:imageRef];
-    CGImageRelease(imageRef);
-    return thumbnail;
-}
+#pragma mark - Table view delegate
 
-- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
-    VaultMediaItem *item = self.items[indexPath.item];
-    if (self.isSelectionMode) {
-        UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
-        UIImageView *checkmarkView = [cell.contentView viewWithTag:100];
-        if ([self.collectionView.indexPathsForSelectedItems containsObject:indexPath]) {
-            [self.collectionView deselectItemAtIndexPath:indexPath animated:YES];
-            cell.backgroundColor = [UIColor clearColor];
-            checkmarkView.hidden = YES;
-        } else {
-            [self.collectionView selectItemAtIndexPath:indexPath animated:YES scrollPosition:UICollectionViewScrollPositionNone];
-            cell.backgroundColor = [UIColor systemBlueColor];
-            checkmarkView.hidden = NO;
-        }
-    } else {
-        if (item.contentType == VaultMediaItemTypePhoto) {
-            PhotoViewController *photoVC = [[PhotoViewController alloc] initWithItems:self.items atIndex:indexPath.item];
-            UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:photoVC];
-            navController.modalPresentationStyle = UIModalPresentationFullScreen;
-            [self presentViewController:navController animated:YES completion:nil];
-        } else {
-            // TODO: Implement video player
-        }
-    }
-}
-
-- (void)handleLongPress:(UILongPressGestureRecognizer *)gestureRecognizer {
-    if (self.isSelectionMode) {
-        if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
-            CGPoint point = [gestureRecognizer locationInView:self.collectionView];
-            NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:point];
-            if (indexPath) {
-                self.initialSelectionState = ![self.collectionView.indexPathsForSelectedItems containsObject:indexPath];
-                self.lastSelectedIndexPath = indexPath;
-                [self updateSelectionForCellAtIndexPath:indexPath];
-            }
-        } else if (gestureRecognizer.state == UIGestureRecognizerStateChanged) {
-            CGPoint point = [gestureRecognizer locationInView:self.collectionView];
-            NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:point];
-            if (indexPath && ![indexPath isEqual:self.lastSelectedIndexPath]) {
-                [self updateSelectionForCellAtIndexPath:indexPath];
-                self.lastSelectedIndexPath = indexPath;
-            }
-        } else if (gestureRecognizer.state == UIGestureRecognizerStateEnded) {
-            self.lastSelectedIndexPath = nil;
-        }
-    } else {
-        if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
-            CGPoint p = [gestureRecognizer locationInView:self.collectionView];
-            NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:p];
-            
-            if (indexPath == nil){
-                NSLog(@"couldn't find index path");
-            } else {
-                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Actions" message:nil preferredStyle:UIAlertControllerStyleActionSheet];
-                
-                VaultMediaItem *item = self.items[indexPath.item];
-
-                NSString *favoriteTitle = item.isFavorite ? @"Unfavorite" : @"Favorite";
-                [alert addAction:[UIAlertAction actionWithTitle:favoriteTitle style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                    item.isFavorite = !item.isFavorite;
-                    [[VaultManager sharedManager] saveVaultItems];
-                    [self.collectionView reloadItemsAtIndexPaths:@[indexPath]];
-                }]];
-
-                [alert addAction:[UIAlertAction actionWithTitle:@"Delete" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
-                    [[VaultManager sharedManager] deleteVaultItem:item];
-                    [self loadItems];
-                }]];
-                
-                [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-                
-                [self presentViewController:alert animated:YES completion:nil];
-            }
-        }
-    }
-}
-
-- (void)updateSelectionForCellAtIndexPath:(NSIndexPath *)indexPath {
-    UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
-    UIImageView *checkmarkView = [cell.contentView viewWithTag:100];
-
-    if (self.initialSelectionState) {
-        [self.collectionView selectItemAtIndexPath:indexPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
-        cell.backgroundColor = [UIColor systemBlueColor];
-        checkmarkView.hidden = NO;
-    } else {
-        [self.collectionView deselectItemAtIndexPath:indexPath animated:NO];
-        cell.backgroundColor = [UIColor clearColor];
-        checkmarkView.hidden = YES;
-    }
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSString *username = self.sortedUsernames[indexPath.row];
+    NSArray<VaultMediaItem *> *items = self.groupedItems[username];
+    
+    VaultContentTypesViewController *contentTypesVC = [[VaultContentTypesViewController alloc] initWithItems:items andUsername:username];
+    [self.navigationController pushViewController:contentTypesVC animated:YES];
 }
 
 @end

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.kunihir0.doux
 Name: DouX
-Version: 1.5.7
+Version: 2.1.0
 Architecture: iphoneos-arm64
 Description: A collection of enhancements for TikTok.
 Maintainer: kunihir0

--- a/hooks/app_delegate.x
+++ b/hooks/app_delegate.x
@@ -1,6 +1,7 @@
 #import "TikTokHeaders.h"
 #import "SecurityViewController.h"
 #import "common.h"
+#import "VaultViewController.h"
 
 %hook AppDelegate
 - (_Bool)application:(UIApplication *)application didFinishLaunchingWithOptions:(id)arg2 {
@@ -21,7 +22,15 @@
         [[NSUserDefaults standardUserDefaults] setBool:true forKey:@"show_vault_button"];
     }
     [DouXManager cleanCache];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(presentVault) name:@"presentVault" object:nil];
     return true;
+}
+
+%new
+- (void)presentVault {
+    VaultViewController *vaultVC = [[VaultViewController alloc] initWithStyle:UITableViewStyleGrouped];
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vaultVC];
+    [topMostController() presentViewController:navController animated:YES completion:nil];
 }
 
 static BOOL isAuthenticationShowed = FALSE;


### PR DESCRIPTION
This commit introduces a number of major changes to the Media Vault feature, as well as several other new features and bug fixes.

**Media Vault Overhaul:**

*   **New Design:** The Media Vault has been completely redesigned with a new, more modern UI.
*   **Encryption:** The Media Vault can now be encrypted with a password. All media files are encrypted using AES256.
*   **Statistics:** A new statistics screen has been added to the vault, which shows a breakdown of the media types and their storage usage.
*   **File Viewer:** The user can now view the contents of other `.dat` files in the app's documents directory.
*   **Exporting:** The user can now export media items from the vault to the photo library. Exported items are deleted from the vault.
*   **Multi-selection:** The user can now select multiple items in the vault to export or delete.

**New Features:**

*   **Block TikTok Shop:** A new option has been added to block videos that contain TikTok Shop products.
*   **Haptic Feedback:** Haptic feedback has been added to the encryption and export processes.
*   **Progress Toasts:** Progress toasts are now shown when encrypting or decrypting the vault.

**Bug Fixes:**

*   Fixed a bug where the app would crash when exporting media to the photo library.
*   Fixed a bug where the user could disable vault encryption without entering a password.
*   Fixed a bug where the user was only asked to enter their password once when enabling vault encryption.
*   Fixed a bug where the wrong password would not be detected when unlocking the vault.
*   Fixed a bug where the UI would not be updated correctly after exporting or deleting media from the vault.